### PR TITLE
fix: Make event links on cards work on deployed web

### DIFF
--- a/src/components/EventCard.astro
+++ b/src/components/EventCard.astro
@@ -1,23 +1,26 @@
 ---
-import type { Event } from '../content/event.ts';
+import type { Event } from "../content/event.ts";
 import Card from "../components/Card.astro";
 
 interface Props {
-  content : Event,
-  class: string
+  content: Event;
+  class: string;
 }
 const { content, class: className } = Astro.props;
 ---
+
 <div class={`relative ${className}`}>
   <Card
     title={content.data.title}
     excerpt={content.data.excerpt}
     date={content.data.date}
-    href={`eventos/${content.id}`}
+    href={`/eventos/${content.id}`}
     tags={content.data.tags}
   />
   <div class="absolute top-4 right-4">
-    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+    <span
+      class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"
+    >
       Próximamente
     </span>
   </div>


### PR DESCRIPTION
Event links from cards weren't working on the deployed web because of the trailing slash (I think). Fixed that making the path absolute