### PR TITLE
feat: add view transitions and change html lang

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from "astro:transitions";
 import "../styles/global.css";
 
 interface Props {
@@ -55,6 +56,9 @@ const imageUrl = `${siteUrl}${image}`;
     <meta property="twitter:title" content={title} />
     <meta property="twitter:description" content={description} />
     <meta property="twitter:image" content={imageUrl} />
+    
+    <!-- View Transitions -->
+    <ClientRouter />
   </head>
   <body class="h-full bg-white">
     <slot />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,7 +15,7 @@ const imageUrl = `${siteUrl}${image}`;
 ---
 
 <!doctype html>
-<html lang="en" class="h-full" transition:name="root" transition:animate="none">
+<html lang="es" class="h-full" transition:name="root" transition:animate="none">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,7 +15,7 @@ const imageUrl = `${siteUrl}${image}`;
 ---
 
 <!doctype html>
-<html lang="en" class="h-full">
+<html lang="en" class="h-full" transition:name="root" transition:animate="none">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -18,7 +18,7 @@ const { title, description, image } = Astro.props;
       <Navigation />
     </header>
     
-    <main class="flex-1 pt-16">
+    <main class="flex-1 pt-16" transition:animate="fade">
       <slot />
     </main>
     


### PR DESCRIPTION
Si, son dos lineas de código, pero la web se siente mucha más fluida si se aprovechan las view transitions de Astro.
Las he configurado para que el header y footer se mantengan mientras que el body cambia. Además mientras lo configuraba vi que el `lang` estaba configurado en inglés cuando la web esta en español, así que aproveche para cambiarlo.