### PR TITLE
feat: Añadir los logos de mastodon y bluesky

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,14 +11,16 @@ import logoSmall from "../assets/logo-small.svg";
       <!-- About -->
       <div class="md:col-span-2">
         <div class="flex items-center space-x-3 mb-4">
-          <Image 
-            src={logoSmall} 
-            alt="GPUL Logo" 
+          <Image
+            src={logoSmall}
+            alt="GPUL Logo"
             width={32}
             height={32}
             class="w-8 h-8"
           />
-          <h3 class="text-lg font-semibold">Grupo de Programadores e Usuarios de Linux</h3>
+          <h3 class="text-lg font-semibold">
+            Grupo de Programadores e Usuarios de Linux
+          </h3>
         </div>
         <p class="text-gray-300 mb-4">
           Defendendo o software libre dende 1998.
@@ -73,14 +75,34 @@ import logoSmall from "../assets/logo-small.svg";
           <li>
             <div class="flex space-x-4 mt-4">
               <a
-                href="https://x.com/gpul_"
+                href="https://mastodon.social/@gpul_"
                 class="text-gray-300 hover:text-white transition-colors"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <span class="sr-only">X (Twitter)</span>
-                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                <span class="sr-only">Mastodon</span>
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 640 640"
+                  ><path
+                    d="m 619.10911,209.93288 c 0,-139.109896 -91.16564,-179.898291 -91.16564,-179.898291 -89.44824,-41.07463 -327.16587,-40.645279 -415.7554,0 0,0 -91.165647,40.788395 -91.165647,179.898291 0,165.58658 -9.445734,371.24596 151.131737,413.75176 57.96246,15.31354 107.76724,18.60523 147.84005,16.31536 72.70352,-4.00728 113.49192,-25.90421 113.49192,-25.90421 l -2.43299,-52.81024 c 0,0 -51.95154,16.31536 -110.34335,14.45484 -57.81934,-2.00364 -118.78725,-6.29716 -128.23299,-77.28328 -0.8587,-6.58339 -1.28805,-13.3099 -1.28805,-19.89329 122.5083,29.91149 227.12696,13.02367 255.75039,9.58885 80.28874,-9.58885 150.27304,-59.10739 159.14631,-104.33242 14.02548,-71.27235 12.88054,-173.88737 12.88054,-173.88737 z m -107.481,179.18271 H 444.9355 V 225.67577 c 0,-71.12924 -91.59499,-73.84846 -91.59499,9.87509 v 89.44823 h -66.26325 v -89.44823 c 0,-83.72355 -91.595,-81.00433 -91.595,-9.87509 v 163.43982 h -66.83572 c 0,-174.74608 -7.44209,-211.67031 26.33356,-250.45506 37.06735,-41.360868 114.20751,-44.080094 148.55563,8.73014 l 16.60159,27.90785 16.6016,-27.90785 c 34.49124,-53.096469 111.77451,-49.804774 148.55563,-8.73014 33.91877,39.07099 26.33356,75.8521 26.33356,250.45506 z"
+                  ></path>
+                </svg></a
+              >
+              <a
+                href="https://mastodon.social/@gpul_"
+                class="text-gray-300 hover:text-white transition-colors"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="sr-only">Bluesky</span>
+                <svg
+                  class="w-5 h-5"
+                  viewBox="0 0 600 530"
+                  version="1.1"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"
+                    fill="currentColor"></path>
                 </svg>
               </a>
               <a
@@ -101,12 +123,24 @@ import logoSmall from "../assets/logo-small.svg";
                 <span class="sr-only">Telegram</span>
                 <Send class="w-5 h-5" />
               </a>
+              <a
+                href="https://x.com/gpul_"
+                class="text-gray-300 hover:text-white transition-colors"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="sr-only">X (Twitter)</span>
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path
+                    d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+                  ></path>
+                </svg>
+              </a>
             </div>
           </li>
         </ul>
       </div>
     </div>
-
     <div class="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
       <p>Grupo de Programadores e Usuarios de Linux</p>
     </div>


### PR DESCRIPTION
Añado los iconos de las redes sociales mastodon y bluesky al footer. Quizás se pueden añadir los sitios que faltan, como web.archive.org. ¿Deberíamos de empezar a subir ahí también las grabaciones de las charlas?