### PR TITLE
feat: Modo oscuro

### DIFF
--- a/src/components/Activities.astro
+++ b/src/components/Activities.astro
@@ -3,47 +3,65 @@ import Code from "lucide-astro/Code";
 import Cpu from "lucide-astro/Cpu";
 import BookOpen from "lucide-astro/BookOpen";
 ---
+
 <!-- Sección: A que nos dedicamos -->
-<section class="py-16 bg-gray-50">
+<section class="py-16 bg-gray-50 dark:bg-neutral-800">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
-      <h2 class="text-3xl font-bold text-gray-900 mb-4">A que nos dedicamos</h2>
-      <p class="text-xl text-gray-600 max-w-3xl mx-auto">
-        Promovemos a cultura libre en todos os seus aspectos: software, hardware e coñecemento.
+      <h2 class="text-3xl font-bold text-gray-900 mb-4 dark:text-white">
+        A que nos dedicamos
+      </h2>
+      <p class="text-xl text-gray-600 dark:text-neutral-300 max-w-3xl mx-auto">
+        Promovemos a cultura libre en todos os seus aspectos: software, hardware
+        e coñecemento.
       </p>
     </div>
-    
+
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div class="text-center p-6">
-        <div class="w-16 h-16 bg-blue-100 rounded-lg flex items-center justify-center mx-auto mb-4">
+        <div
+          class="w-16 h-16 bg-blue-100 rounded-lg flex items-center justify-center mx-auto mb-4"
+        >
           <Code class="w-8 h-8 text-blue-600" />
         </div>
-        <h3 class="text-xl font-semibold text-gray-900 mb-3">Software libre</h3>
-        <p class="text-gray-600">
-          Ver e reutilizar o código é fundamental para aprender, para estar seguros de ter privacidade e para mellorar o software.
+        <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+          Software libre
+        </h3>
+        <p class="text-gray-600 dark:text-neutral-300">
+          Ver e reutilizar o código é fundamental para aprender, para estar
+          seguros de ter privacidade e para mellorar o software.
         </p>
       </div>
-      
+
       <div class="text-center p-6">
-        <div class="w-16 h-16 bg-green-100 rounded-lg flex items-center justify-center mx-auto mb-4">
+        <div
+          class="w-16 h-16 bg-green-100 rounded-lg flex items-center justify-center mx-auto mb-4"
+        >
           <Cpu class="w-8 h-8 text-green-600" />
         </div>
-        <h3 class="text-xl font-semibold text-gray-900 mb-3">Hardware libre</h3>
-        <p class="text-gray-600">
-          Igual que no software, no hardware tamén se poden publicar os planos e deseños para democratizar o acceso a tecnoloxía.
+        <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+          Hardware libre
+        </h3>
+        <p class="text-gray-600 dark:text-neutral-300">
+          Igual que no software, no hardware tamén se poden publicar os planos e
+          deseños para democratizar o acceso a tecnoloxía.
         </p>
       </div>
-      
+
       <div class="text-center p-6">
-        <div class="w-16 h-16 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-4">
+        <div
+          class="w-16 h-16 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-4"
+        >
           <BookOpen class="w-8 h-8 text-purple-600" />
         </div>
-        <h3 class="text-xl font-semibold text-gray-900 mb-3">Coñecemento libre</h3>
-        <p class="text-gray-600">
-          Non nos podemos olvidar da importancia de compartir coñecemento libremente, sen restricións, mellorando a sociedade.
+        <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+          Coñecemento libre
+        </h3>
+        <p class="text-gray-600 dark:text-neutral-300">
+          Non nos podemos olvidar da importancia de compartir coñecemento
+          libremente, sen restricións, mellorando a sociedade.
         </p>
       </div>
     </div>
   </div>
 </section>
-

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -39,10 +39,10 @@ const CardTag = href ? "a" : "div";
 
 <CardTag
   href={href}
-  class={`w-sm h-full p-3 bg-white block rounded-lg shadow-md overflow-hidden
+  class={`w-sm h-full p-3 bg-white block dark:bg-neutral-800 rounded-lg shadow-md overflow-hidden
           transition-transform duration-200 hover:scale-102
           hover:shadow-lg ${href == "a" ? "cursor-pointer" : ""} ${className}`}
-  data-filtrable={tags.join(' ')}
+  data-filtrable={tags.join(" ")}
 >
   {
     image ? (
@@ -66,7 +66,7 @@ const CardTag = href ? "a" : "div";
       tags.length > 0 && (
         <div class="flex flex-wrap gap-2 mb-3">
           {tags.map((tag) => (
-            <span class="px-2 py-1 bg-blue-100 text-blue-800 text-xs font-semibold rounded-full">
+            <span class="px-2 py-1 bg-blue-100 text-blue-800 dark:bg-blue-300 dark:text-blue-800 text-xs font-semibold rounded-full">
               {tag}
             </span>
           ))}
@@ -74,13 +74,23 @@ const CardTag = href ? "a" : "div";
       )
     }
 
-    <h3 class="text-xl font-semibold text-gray-900 mb-3 line-clamp-2 h-13">
+    <h3
+      class="text-xl font-semibold text-gray-900 dark:text-white mb-3 line-clamp-2 h-13"
+    >
       {title}
     </h3>
 
-    {excerpt && <p class="text-gray-600 mb-4 line-clamp-3 h-18">{excerpt}</p>}
+    {
+      excerpt && (
+        <p class="text-gray-600 dark:text-neutral-400 mb-4 line-clamp-3 h-18">
+          {excerpt}
+        </p>
+      )
+    }
 
-    <div class="flex items-center justify-between text-sm text-gray-500">
+    <div
+      class="flex items-center justify-between text-sm text-gray-500 dark:text-neutral-300"
+    >
       <div class="flex items-center space-x-4">
         {author && <span class="font-medium">{author}</span>}
         {date && <time datetime={date.toString()}>{formatDate(date)}</time>}
@@ -88,7 +98,7 @@ const CardTag = href ? "a" : "div";
 
       {
         href && (
-          <span class="text-blue-600 font-medium flex items-center">
+          <span class="text-blue-600 dark:text-blue-500 font-medium flex items-center">
             Ler máis
             <ChevronRight class="ml-1 w-4 h-4" />
           </span>

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -3,25 +3,30 @@ import Loader from "lucide-astro/Loader";
 import Check from "lucide-astro/Check";
 import SimpleInput from "./SimpleIntput.astro";
 
-
 const { class: className } = Astro.props;
 ---
-<div class={`bg-gray-100 rounded-2xl p-8 m-auto h-fit ${className}`}>
-  <h2 class="text-2xl font-bold text-gray-900 mb-6">Envíanos unha mensaxe</h2>
-  
+
+<div
+  class={`bg-gray-100 dark:bg-neutral-800 rounded-2xl p-8 m-auto h-fit ${className}`}
+>
+  <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+    Envíanos unha mensaxe
+  </h2>
+
   <form id="contact-form" class="space-y-6">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <SimpleInput name="name" type="text" placeholder="O teu nome">
         Nome
       </SimpleInput>
-      <SimpleInput
-        name="surname"
-        type="text"
-        placeholder="Os teus apelidos"
-      >
+      <SimpleInput name="surname" type="text" placeholder="Os teus apelidos">
         Apelidos
       </SimpleInput>
-      <SimpleInput name="phone" type="tel" placeholder="123456789" class="phone">
+      <SimpleInput
+        name="phone"
+        type="tel"
+        placeholder="123456789"
+        class="phone"
+      >
         Teléfono
       </SimpleInput>
       <SimpleInput name="mail" type="email" placeholder="teu@email.com">
@@ -30,29 +35,28 @@ const { class: className } = Astro.props;
     </div>
 
     <div>
-      <SimpleInput name="subject" type="select" placeholder={[
-        { value:"", text: "Selecciona un asunto"},
-        { value:"socio", text: "Quero ser socio"},
-        { value:"evento", text: "Consulta sobre eventos"},
-        { value:"colaboracion", text: "Proposta de colaboración"},
-        { value:"charla", text: "Propor charla/taller"},
-        { value:"outro", text: "Outro"},
-      ]}>
+      <SimpleInput
+        name="subject"
+        type="select"
+        placeholder={[
+          { value: "", text: "Selecciona un asunto" },
+          { value: "socio", text: "Quero ser socio" },
+          { value: "evento", text: "Consulta sobre eventos" },
+          { value: "colaboracion", text: "Proposta de colaboración" },
+          { value: "charla", text: "Propor charla/taller" },
+          { value: "outro", text: "Outro" },
+        ]}
+      >
         Asunto
       </SimpleInput>
-
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <SimpleInput name="dni" type="text" placeholder="12345678A">
         DNI/NIE/Pasaporte
       </SimpleInput>
-      <SimpleInput name="birth" type="date">
-        Data de nacemento
-      </SimpleInput>
-      <SimpleInput name="address" type="text">
-        Enderezo completo
-      </SimpleInput>
+      <SimpleInput name="birth" type="date"> Data de nacemento </SimpleInput>
+      <SimpleInput name="address" type="text"> Enderezo completo </SimpleInput>
       <SimpleInput
         name="occupation"
         type="text"
@@ -65,110 +69,133 @@ const { class: className } = Astro.props;
         Estudas na UDC
       </SimpleInput>
     </div>
-    <SimpleInput name="message" type="textarea" placeholder="Escribe aquí a túa mensaxe...">
+    <SimpleInput
+      name="message"
+      type="textarea"
+      placeholder="Escribe aquí a túa mensaxe..."
+    >
       Mensaxe
     </SimpleInput>
 
     <SimpleInput name="privacy-policy" type="checkbox">
-        Acepto a <a href="#" class="text-blue-600 hover:text-blue-700">política de privacidade</a>
+      Acepto a <a
+        href="#"
+        class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+        >política de privacidade</a
+      >
     </SimpleInput>
 
-    <button 
+    <button
       type="submit"
-      class="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 font-medium flex justify-center gap-4"
+      class="w-full bg-blue-600 dark:bg-blue-400 text-white py-3 px-4 rounded-md hover:bg-blue-700 dark:hover:bg-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 font-medium flex justify-center gap-4"
     >
       Enviar mensaxe
-      <Loader class="loader hidden"/>
-      <Check class="check hidden "/>
+      <Loader class="loader hidden" />
+      <Check class="check hidden" />
     </button>
   </form>
-
 </div>
 
 {/* Send form data and animate form */}
-<script is:inline defer>{
-  const form = document.querySelector('#contact-form');
-  const loader = form.querySelector('.loader')
-  const check = form.querySelector('.check')
+<script is:inline defer>
+  {
+    const form = document.querySelector("#contact-form");
+    const loader = form.querySelector(".loader");
+    const check = form.querySelector(".check");
 
-  const startLoad = () => {
-    loader.classList.remove("hidden")
-    loader.classList.add("animate-spin")
+    const startLoad = () => {
+      loader.classList.remove("hidden");
+      loader.classList.add("animate-spin");
+    };
+
+    const endLoad = () => {
+      loader.classList.add("hidden");
+      loader.classList.remove("animate-spin");
+
+      check.classList.remove("hidden");
+      check.classList.add("animate-bounce");
+      setTimeout(() => check.classList.add("hidden"), 500);
+    };
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+
+      startLoad();
+
+      try {
+        const response = await fetch(
+          "https://activepieces.gpul.org/api/v1/webhooks/0c0o5NPbtpg4ddEjWiD3p",
+          {
+            method: "POST",
+            body: new FormData(form),
+          }
+        );
+      } catch (error) {
+        console.error(error);
+      }
+
+      endLoad();
+    });
   }
-
-  const endLoad = () => {
-    loader.classList.add("hidden")
-    loader.classList.remove("animate-spin")
-
-    check.classList.remove("hidden")
-    check.classList.add("animate-bounce")
-    setTimeout(() => check.classList.add("hidden"), 500)
-  }
-
-  form.addEventListener('submit', async event => {
-    event.preventDefault();
-
-    startLoad()
-
-    try {
-      const response = await fetch("https://activepieces.gpul.org/api/v1/webhooks/0c0o5NPbtpg4ddEjWiD3p", {
-        method: "POST",
-        body: new FormData(form),
-      })
-    } catch (error) {
-      console.error(error);
-    }
-
-    endLoad()
-
-  })
-}</script>
+</script>
 
 {/* Set the subject of the select automatically from the url params */}
-<script is:inline defer>{
-  /** @type {HTMLSelectElement} */
-  const select = document.querySelector('#subject select')
+<script is:inline defer>
+  {
+    /** @type {HTMLSelectElement} */
+    const select = document.querySelector("#subject select");
 
-  const subjectParam = new URLSearchParams(document.location.search).get('asunto') ?? ''
+    const subjectParam =
+      new URLSearchParams(document.location.search).get("asunto") ?? "";
 
-  const options = [...select.options].map(option => option.value)
+    const options = [...select.options].map((option) => option.value);
 
-  if(options.includes(subjectParam)) {
-    select.value = subjectParam
-  }
-
-}</script>
-
-{/* React to subject changes */}
-<script is:inline defer>{
-    
-  /** @type {HTMLSelectElement} */
-  const select = document.querySelector('#subject select')
-  /** @type {HTMLFormElement} */
-  const form = document.querySelector('#contact-form')
-
-  const formVariants = {
-    default: ['name', 'mail', 'message'],
-    socio: ['name', 'surname', 'phone', 'mail', 'dni', 'birth', 'address', 'occupation', 'udc-student']
-  }
-
-  const formConstants = ['subject', 'privacy-policy', '']
-
-  const setFormElements =  () => {
-    const selected = select.value
-    const variant = formVariants[selected] ?? formVariants.default
-
-    for(const element of form.elements) {
-      if(formConstants.includes(element.name)) continue;
-
-      const needed = variant.includes(element.name)
-
-      element.parentElement.classList.toggle('hidden', !needed)
-      element.disabled = !needed
+    if (options.includes(subjectParam)) {
+      select.value = subjectParam;
     }
   }
+</script>
 
-  setFormElements()
-  select.addEventListener('change', setFormElements)
-}</script>
+{/* React to subject changes */}
+<script is:inline defer>
+  {
+    /** @type {HTMLSelectElement} */
+    const select = document.querySelector("#subject select");
+    /** @type {HTMLFormElement} */
+    const form = document.querySelector("#contact-form");
 
+    const formVariants = {
+      default: ["name", "mail", "message"],
+      socio: [
+        "name",
+        "surname",
+        "phone",
+        "mail",
+        "dni",
+        "birth",
+        "address",
+        "occupation",
+        "udc-student",
+      ],
+    };
+
+    const formConstants = ["subject", "privacy-policy", ""];
+
+    const setFormElements = () => {
+      const selected = select.value;
+      const variant = formVariants[selected] ?? formVariants.default;
+
+      for (const element of form.elements) {
+        if (formConstants.includes(element.name)) continue;
+
+        const needed = variant.includes(element.name);
+
+        element.parentElement.classList.toggle("hidden", !needed);
+        element.disabled = !needed;
+      }
+    };
+
+    setFormElements();
+    select.addEventListener("change", setFormElements);
+  }
+</script>

--- a/src/components/ContactInfo.astro
+++ b/src/components/ContactInfo.astro
@@ -1,21 +1,31 @@
 ---
 import Mail from "lucide-astro/Mail";
 import MapPin from "lucide-astro/MapPin";
-import Twitter  from "lucide-astro/Twitter";
+import Twitter from "lucide-astro/Twitter";
 
 const { class: className } = Astro.props;
 ---
+
 <!-- Información de contacto -->
 <div class={`space-y-6 ${className}`}>
   <!-- Email -->
   <div class="flex items-start space-x-4">
-    <div class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
+    <div
+      class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center"
+    >
       <Mail class="w-5 h-5 text-blue-600" />
     </div>
     <div>
-      <h3 class="text-lg font-semibold text-gray-900 mb-1">Email</h3>
-      <p class="text-gray-600 mb-2">Para consultas xerais e información</p>
-      <a href="mailto:info@gpul.org" class="text-blue-600 hover:text-blue-700 font-medium">
+      <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+        Email
+      </h3>
+      <p class="text-gray-600 dark:text-gray-400 mb-2">
+        Para consultas xerais e información
+      </p>
+      <a
+        href="mailto:info@gpul.org"
+        class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium"
+      >
         info@gpul.org
       </a>
     </div>
@@ -23,14 +33,18 @@ const { class: className } = Astro.props;
 
   <!-- Localización -->
   <div class="flex items-start space-x-4">
-    <div class="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
+    <div
+      class="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center"
+    >
       <MapPin class="w-5 h-5 text-purple-600" />
     </div>
     <div>
-      <h3 class="text-lg font-semibold text-gray-900 mb-1">Localización</h3>
-      <p class="text-gray-600">
-        Facultade de Informática<br>
-        Campus de Elviña s/n<br>
+      <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+        Localización
+      </h3>
+      <p class="text-gray-600 dark:text-gray-400">
+        Facultade de Informática<br />
+        Campus de Elviña s/n<br />
         15071 A Coruña, España
       </p>
     </div>
@@ -38,18 +52,35 @@ const { class: className } = Astro.props;
 
   <!-- Redes sociais -->
   <div class="flex space-x-4">
-    <div class="w-10 h-10 bg-indigo-100 rounded-lg flex items-center justify-center">
+    <div
+      class="w-10 h-10 bg-indigo-100 rounded-lg flex items-center justify-center"
+    >
       <Twitter class="w-5 h-5 text-indigo-600" />
     </div>
     <div>
-      <h3 class="text-lg font-semibold text-gray-900 mb-1">Redes sociais</h3>
-      <p class="text-gray-600 mb-2">Síguenos nas redes sociais</p>
+      <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+        Redes sociais
+      </h3>
+      <p class="text-gray-600 dark:text-gray-400 mb-2">
+        Síguenos nas redes sociais
+      </p>
       <div class="flex space-x-4">
-        <a href="#" class="text-blue-600 hover:text-blue-700">Twitter</a>
-        <a href="#" class="text-blue-600 hover:text-blue-700">GitHub</a>
-        <a href="#" class="text-blue-600 hover:text-blue-700">Telegram</a>
+        <a
+          href="#"
+          class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+          >Twitter</a
+        >
+        <a
+          href="#"
+          class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+          >GitHub</a
+        >
+        <a
+          href="#"
+          class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+          >Telegram</a
+        >
       </div>
     </div>
   </div>
 </div>
-

--- a/src/components/ContactMap.astro
+++ b/src/components/ContactMap.astro
@@ -1,8 +1,16 @@
 ---
 const { class: className } = Astro.props;
 ---
+
 <!-- Mapa -->
 <div class={`sm:min-w-2xl ${className}`}>
-  <h3 class="text-lg font-semibold text-gray-900 mb-4">Onde estamos</h3>
-  <iframe width="100%" height="500px" class="rounded-lg" src="https://www.openstreetmap.org/export/embed.html?bbox=-8.412598371505739%2C43.331932463082026%2C-8.40905785560608%2C43.333766387744994&amp;layer=mapnik&amp;marker=43.332849432336026%2C-8.410828113555908"></iframe>
+  <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+    Onde estamos
+  </h3>
+  <iframe
+    width="100%"
+    height="500px"
+    class="rounded-lg"
+    src="https://www.openstreetmap.org/export/embed.html?bbox=-8.412598371505739%2C43.331932463082026%2C-8.40905785560608%2C43.333766387744994&layer=mapnik&marker=43.332849432336026%2C-8.410828113555908"
+  ></iframe>
 </div>

--- a/src/components/Filter.astro
+++ b/src/components/Filter.astro
@@ -1,84 +1,91 @@
 ---
 interface Props {
-  tags: string[]
+  tags: string[];
 }
 
-const {
-  tags
-} = Astro.props;
+const { tags } = Astro.props;
 
 const tagClass = `
     block px-4 py-2 border rounded-full whitespace-nowrap h-max text-sm
     transition-colors cursor-pointer 
-    bg-white has-checked:bg-blue-600
+    bg-white dark:bg-neutral-700 dark:text-white dark:border-neutral-500 has-checked:bg-blue-600 dark:has-checked:bg-blue-500 dark:hover:has-checked:bg-blue-400 dark:hover:bg-neutral-500
     text-gray-700 has-checked:text-white
-    hover:bg-gray-100 has-checked:hover:bg-blue-700`
+    hover:bg-gray-100 has-checked:hover:bg-blue-700`;
 ---
 
-<section class="py-3 bg-gray-50 border-b flex flex-row gap-3">
+<section
+  class="py-3 bg-gray-50 dark:bg-neutral-800 border-b flex flex-row gap-3"
+>
   <div class="max-w-7xl mx-auto flex gap-3 px-4 overflow-hidden">
     <label class={tagClass}>
-      <input
-        data-filter="all" checked
-        type="checkbox" class="hidden"
-      />
+      <input data-filter="all" checked type="checkbox" class="hidden" />
       Todas
     </label>
     <div class="flex gap-3 place-center overflow-x-scroll" id="filters">
       {
-        tags.map(name =>
+        tags.map((name) => (
           <label class={tagClass}>
             <input data-filter={name} type="checkbox" class="hidden" />
             {name}
           </label>
-        )
+        ))
       }
     </div>
   </div>
 
-  <script is:inline defer>window.addEventListener("load", ()=>{
-    const allCheckbox = document.querySelector('[data-filter="all"]');
-    const otherCheckboxes = document.querySelectorAll('[data-filter]:not([data-filter="all"])');
-    const filtrables = document.querySelectorAll(`[data-filtrable]`);
-    const filtrableWithTag = tag => document.querySelectorAll(`[data-filtrable~="${tag}"]`);
+  <script is:inline defer>
+    window.addEventListener("load", () => {
+      const allCheckbox = document.querySelector('[data-filter="all"]');
+      const otherCheckboxes = document.querySelectorAll(
+        '[data-filter]:not([data-filter="all"])'
+      );
+      const filtrables = document.querySelectorAll(`[data-filtrable]`);
+      const filtrableWithTag = (tag) =>
+        document.querySelectorAll(`[data-filtrable~="${tag}"]`);
 
-    const showContent = content => content.classList.remove("hidden")
-    const hideContent = content => content.classList.add("hidden")
+      const showContent = (content) => content.classList.remove("hidden");
+      const hideContent = (content) => content.classList.add("hidden");
 
-    allCheckbox.addEventListener("change", () => {
-      // Ignore turning off all
-      if (!allCheckbox.checked) { allCheckbox.checked = true }
-      // Uncheck other filters
-      otherCheckboxes.forEach(cb => cb.checked = false);
-      // Show every filtrable
-      filtrables.forEach(showContent)
-    });
-
-    otherCheckboxes.forEach(cb => {
-      cb.addEventListener("change", () => {
-        // Uncheck all filter
-        allCheckbox.checked = false;
-        // Take all checked filters
-        const filters = [...document.querySelectorAll(`[data-filter]:checked`)
-          .values().map(tag => tag.dataset.filter)];
-
-        // Show everything if no tag is selected
-        if(filters.length == 0) {
-          filtrables.forEach(showContent);
+      allCheckbox.addEventListener("change", () => {
+        // Ignore turning off all
+        if (!allCheckbox.checked) {
           allCheckbox.checked = true;
-          return;
-        } 
+        }
+        // Uncheck other filters
+        otherCheckboxes.forEach((cb) => (cb.checked = false));
+        // Show every filtrable
+        filtrables.forEach(showContent);
+      });
 
-        // Hide everything
-        filtrables.forEach(hideContent);
-        console.log({filtrables})
-        // Show selected content
-        filters.forEach( tag => {
-          console.log(filtrableWithTag(tag))
-          filtrableWithTag(tag).forEach(showContent)
+      otherCheckboxes.forEach((cb) => {
+        cb.addEventListener("change", () => {
+          // Uncheck all filter
+          allCheckbox.checked = false;
+          // Take all checked filters
+          const filters = [
+            ...document
+              .querySelectorAll(`[data-filter]:checked`)
+              .values()
+              .map((tag) => tag.dataset.filter),
+          ];
+
+          // Show everything if no tag is selected
+          if (filters.length == 0) {
+            filtrables.forEach(showContent);
+            allCheckbox.checked = true;
+            return;
+          }
+
+          // Hide everything
+          filtrables.forEach(hideContent);
+          console.log({ filtrables });
+          // Show selected content
+          filters.forEach((tag) => {
+            console.log(filtrableWithTag(tag));
+            filtrableWithTag(tag).forEach(showContent);
+          });
         });
       });
     });
-
-  })</script>
+  </script>
 </section>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -17,10 +17,12 @@ const navItems: NavItem[] = [
 ];
 
 /// In dev pathname ends without '/' but in prod it does
-const currentPath = "/" + Astro.url.pathname.split('/')[1];
+const currentPath = "/" + Astro.url.pathname.split("/")[1];
 ---
 
-<nav class="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-md shadow-sm text-gray-800 border-b border-blue-100/50">
+<nav
+  class="fixed top-0 left-0 right-0 z-50 bg-white/80 dark:bg-neutral-800/80 backdrop-blur-md shadow-sm text-gray-800 border-b border-blue-100/50 dark:border-neutral-700"
+>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16">
       <!-- Logo/Brand -->
@@ -34,8 +36,10 @@ const currentPath = "/" + Astro.url.pathname.split('/')[1];
             class="w-10 h-10"
           />
           <div>
-            <h1 class="text-xl font-bold text-gray-800">GPUL</h1>
-            <p class="text-xs text-gray-500">
+            <h1 class="text-xl font-bold text-gray-800 dark:text-white">
+              GPUL
+            </h1>
+            <p class="text-xs text-gray-500 dark:text-neutral-400">
               Grupo de Programadores e Usuarios de Linux
             </p>
           </div>
@@ -51,8 +55,8 @@ const currentPath = "/" + Astro.url.pathname.split('/')[1];
                 href={item.href}
                 class={`px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 ${
                   currentPath === item.href
-                    ? "bg-blue-100 text-blue-700"
-                    : "text-gray-600 hover:bg-blue-50 hover:text-blue-600"
+                    ? "bg-blue-100 dark:bg-blue-300 text-blue-700 dark:text-blue-800"
+                    : "text-gray-600 dark:text-neutral-400 hover:bg-blue-50 dark:hover:bg-blue-300 hover:text-blue-600 dark:hover:text-blue-800"
                 }`}
               >
                 {item.name}
@@ -66,7 +70,7 @@ const currentPath = "/" + Astro.url.pathname.split('/')[1];
       <div class="md:hidden">
         <button
           type="button"
-          class="bg-white inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-blue-600 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-500"
+          class="bg-white dark:bg-neutral-800 dark:border dark:border-neutral-700 inline-flex items-center justify-center p-2 rounded-md text-gray-600 dark:text-neutral-400 hover:text-blue-600 dark:hover:text-blue-800 hover:bg-blue-50 dark:hover:bg-blue-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-500"
           id="mobile-menu-button"
         >
           <span class="sr-only">Abrir menú principal</span>
@@ -78,15 +82,17 @@ const currentPath = "/" + Astro.url.pathname.split('/')[1];
 
   <!-- Mobile Navigation -->
   <div class="md:hidden hidden" id="mobile-menu">
-    <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-blue-100">
+    <div
+      class="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white dark:bg-neutral-800 border-t border-blue-100"
+    >
       {
         navItems.map((item) => (
           <a
             href={item.href}
             class={`block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 ${
               currentPath === item.href
-                ? "bg-blue-100 text-blue-700"
-                : "text-gray-600 hover:bg-blue-50 hover:text-blue-600"
+                ? "bg-blue-100 dark:bg-blue-300 text-blue-700 dark:text-blue-800"
+                : "text-gray-600 dark:text-neutral-400 hover:bg-blue-50 dark:hover:bg-blue-300 hover:text-blue-600 dark:hover:text-blue-800"
             }`}
           >
             {item.name}

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -1,6 +1,9 @@
 ---
+
 ---
 
-<div class="space-y-3 prose-h2:text-3xl prose-h2:font-bold prose-ul:list-disc prose-ul:px-8 prose-a:text-blue-600 prose-a:hover:underline">
+<div
+  class="space-y-3 prose-h2:text-3xl prose-h2:font-bold prose-ul:list-disc prose-ul:px-8 prose-a:text-blue-600 prose-a:hover:underline dark:prose-a:text-blue-400"
+>
   <slot />
 </div>

--- a/src/components/SimpleIntput.astro
+++ b/src/components/SimpleIntput.astro
@@ -1,93 +1,98 @@
 ---
 type Select = {
   type: "select";
-  placeholder: {value: string, text: string}[];
-}
+  placeholder: { value: string; text: string }[];
+};
 
 type Input = {
   type: "text" | "email" | "date" | "tel";
   placeholder?: string;
-}
+};
 
 type TextArea = {
   type: "textarea";
   placeholder?: string;
-}
+};
 
 type CheckBox = {
   type: "checkbox";
   placeholder?: string;
-}
+};
 const CheckBoxClass = `flex flex-row-reverse justify-end gap-3`;
 
-type Props = { name: string, required?: boolean, class?: string} & (
-  Input | Select | TextArea | CheckBox
-)
+type Props = { name: string; required?: boolean; class?: string } & (
+  | Input
+  | Select
+  | TextArea
+  | CheckBox
+);
 
 const props = Astro.props;
-const { name, required = true, type, placeholder, class: className = '' } = props;
+const {
+  name,
+  required = true,
+  type,
+  placeholder,
+  class: className = "",
+} = props;
 
 const safeName = name
   .toLowerCase()
   // Remove all accents
-  .normalize('NFD').replaceAll(/[\u0300-\u036f]/g, '')
+  .normalize("NFD")
+  .replaceAll(/[\u0300-\u036f]/g, "")
   // Convert all non alphanumeric to dashes
-  .replaceAll(/[^a-z0-9]+/g, '-')
+  .replaceAll(/[^a-z0-9]+/g, "-");
 ---
 
 <div
-  class={className + (type == 'checkbox' ? CheckBoxClass : '')}
-  id={safeName} 
+  class={className + (type == "checkbox" ? CheckBoxClass : "")}
+  id={safeName}
 >
-  <label for={safeName} class="block text-sm font-medium text-gray-700 mb-1">
+  <label
+    for={safeName}
+    class="block text-sm font-medium text-gray-700 dark:text-white mb-1"
+  >
     <slot>
       {name}
     </slot>
-      { required && <i class="text-red-600">*</i> }
+    {required && <i class="text-red-600">*</i>}
   </label>
   {
-    type == "select" ?
-
-      <select 
+    type == "select" ? (
+      <select
         name={safeName}
         required={required}
-        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 dark:text-neutral-300"
       >
         {/* Los tipos de ts son de papel mojado :( */}
-        { (placeholder as Select['placeholder']).map( ({value, text}) =>
+        {(placeholder as Select["placeholder"]).map(({ value, text }) => (
           <option value={value}>{text}</option>
-        )}
+        ))}
       </select>
-
-    : type == "textarea" ?
-
-      <textarea 
-        name={safeName} 
+    ) : type == "textarea" ? (
+      <textarea
+        name={safeName}
         rows="5"
         required={required}
-        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-        placeholder={placeholder as TextArea['placeholder']}
-      ></textarea>
-
-    : type == "checkbox" ?
-
+        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 dark:text-neutral-300"
+        placeholder={placeholder as TextArea["placeholder"]}
+      />
+    ) : type == "checkbox" ? (
       <input
         name={name}
-        type="checkbox" 
+        type="checkbox"
         required={required}
         class="focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded"
       />
-
-    :
-
+    ) : (
       <input
-        type={type as Input['type']} 
-        name={safeName} 
+        type={type as Input["type"]}
+        name={safeName}
         required={required}
-        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-        placeholder={placeholder as Input['placeholder']}
+        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 dark:text-neutral-300"
+        placeholder={placeholder as Input["placeholder"]}
       />
-
+    )
   }
-
 </div>

--- a/src/components/StarContent.astro
+++ b/src/components/StarContent.astro
@@ -2,8 +2,10 @@
 <section class="py-16">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
-      <h2 class="text-3xl font-bold text-gray-900 mb-4">Os Nosos Fregados</h2>
-      <p class="text-xl text-gray-600">
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+        Os Nosos Fregados
+      </h2>
+      <p class="text-xl text-gray-600 dark:text-neutral-400">
         Grandes eventos que organizamos cada ano
       </p>
     </div>

--- a/src/components/Stats.astro
+++ b/src/components/Stats.astro
@@ -1,6 +1,5 @@
-
 <!-- Stats -->
-<section class="py-12 bg-white">
+<section class="py-12 bg-white dark:bg-neutral-800">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8 text-center">
       <div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -56,7 +56,7 @@ const imageUrl = `${siteUrl}${image}`;
     <meta property="twitter:description" content={description} />
     <meta property="twitter:image" content={imageUrl} />
   </head>
-  <body class="h-full bg-white">
+  <body class="h-full bg-white dark:bg-neutral-900">
     <slot />
   </body>
 </html>

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -7,24 +7,23 @@ import ContactForm from "../components/ContactForm.astro";
 import ContactMap from "../components/ContactMap.astro";
 ---
 
-<PageLayout 
-  title="Contacto - GPUL" 
+<PageLayout
+  title="Contacto - GPUL"
   description="Ponte en contacto co Grupo de Programadores e Usuarios de Linux (GPUL). Información sobre como asociarse, colaborar ou participar nas nosas actividades."
 >
-  <PageTitle 
-    title="Contacto" 
+  <PageTitle
+    title="Contacto"
     subtitle="Tes algunha dúbida? Queres participar nas nosas actividades? Contacta connosco!"
   />
 
-<section class="my-6 max-w-7xl m-auto">
-  <h2 class="text-3xl font-bold text-gray-900 m-8">
-    Como contactar connosco
-  </h2>
-  <div class="flex gap-8 flex-wrap p-6">
-    <ContactInfo/>
-    <ContactForm class="flex-grow"/>
-    <ContactMap class="flex-grow"/>
-  </div>
-</section>
-
+  <section class="my-6 max-w-7xl m-auto">
+    <h2 class="text-3xl font-bold text-gray-900 dark:text-white m-8">
+      Como contactar connosco
+    </h2>
+    <div class="flex gap-8 flex-wrap p-6">
+      <ContactInfo />
+      <ContactForm class="flex-grow" />
+      <ContactMap class="flex-grow" />
+    </div>
+  </section>
 </PageLayout>

--- a/src/pages/eventos.astro
+++ b/src/pages/eventos.astro
@@ -6,34 +6,38 @@ import EventCard from "../components/EventCard.astro";
 import ContentDisplay from "../components/ContentDisplay.astro";
 
 import Plus from "lucide-astro/Plus";
-import { upcomingEvents, pastEvents } from '../content/event.ts';
+import { upcomingEvents, pastEvents } from "../content/event.ts";
 import StarContent from "../components/StarContent.astro";
 ---
 
-<PageLayout 
-  title="Eventos - GPUL" 
+<PageLayout
+  title="Eventos - GPUL"
   description="Descubre os próximos eventos, charlas, cursos e actividades organizadas polo Grupo de Programadores e Usuarios de Linux (GPUL)."
 >
-  <PageTitle 
-    title="Eventos GPUL" 
+  <PageTitle
+    title="Eventos GPUL"
     subtitle="Participa nas nosas actividades, aprende novas tecnoloxías e conecta coa comunidade"
   />
 
-  <Stats/>
+  <Stats />
 
   <!-- Eventos próximos -->
   <ContentDisplay contents={upcomingEvents} card={EventCard}>
     <Fragment slot="title">
-      <h2 class="text-3xl font-bold text-gray-900 mb-4">Próximos Eventos</h2>
-      <p class="text-xl text-gray-600">
+      <h2
+        class="text-3xl font-bold text-gray-900 dark:text-white dark:mt-8 mb-4"
+      >
+        Próximos Eventos
+      </h2>
+      <p class="text-xl text-gray-600 dark:text-neutral-400">
         Non te perdas as nosas próximas actividades
       </p>
     </Fragment>
 
     <Fragment slot="cta">
       <div class="text-center mt-12">
-        <a 
-          href="/contact" 
+        <a
+          href="/contact"
           class="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
         >
           Propón un evento
@@ -43,17 +47,18 @@ import StarContent from "../components/StarContent.astro";
     </Fragment>
   </ContentDisplay>
 
-  <StarContent/>
+  <StarContent />
 
   <!-- Eventos pasados -->
   <ContentDisplay contents={pastEvents} card={EventCard}>
     <Fragment slot="title">
-      <h2 class="text-3xl font-bold text-gray-900">Eventos Anteriores</h2>
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-white">
+        Eventos Anteriores
+      </h2>
       <!-- TODO: can't we doomscroll this as well -->
       <!-- <a href="/blog" class="text-blue-600 hover:text-blue-700 font-medium"> -->
-        <!-- Ver todas as crónicas → -->
+      <!-- Ver todas as crónicas → -->
       <!-- </a> -->
     </Fragment>
   </ContentDisplay>
-
 </PageLayout>

--- a/src/pages/eventos/[...id].astro
+++ b/src/pages/eventos/[...id].astro
@@ -27,15 +27,15 @@ const { Content } = await render(evento);
   image={`media/eventos/${evento.id}.png`}
 >
   <div
-    class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-8 space-y-3"
+    class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-8 space-y-3 dark:text-white"
     id="event-body"
   >
-    <h1 class="text-5xl font-semibold">{evento.data.title}</h1>
+    <h1 class="text-5xl font-semibold dark:text-white">{evento.data.title}</h1>
     {
       evento.data.tags.length > 0 && (
         <div class="flex flex-wrap gap-2 mb-4 mt-2">
           {evento.data.tags.map((tag) => (
-            <span class="px-2 py-1 bg-blue-100 text-blue-800 text-xs font-semibold rounded-full">
+            <span class="px-2 py-1 bg-blue-100 text-blue-800 dark:bg-blue-300 dark:text-blue-800 text-xs font-semibold rounded-full">
               {tag}
             </span>
           ))}
@@ -50,15 +50,15 @@ const { Content } = await render(evento);
           class="aspect-video rounded-lg"
         />
 
-    <div class="bg-orange-100 border border-orange-500 p-4 rounded-md">
+    <div class="bg-orange-100 border border-orange-500 p-4 rounded-md dark:bg-orange-950">
       <!-- leading-x no aplica el espacio a los iconos -->
       <ul>
         {evento.data.date &&
           <li class="mb-1.5"><Calendar class="float-left mr-1"></Calendar><b>Data:</b> {evento.data.date.toLocaleDateString("es-ES")}</li>
           <li class="mb-1.5"><Clock class="float-left mr-1"></Clock><b>Hora:</b> {evento.data.date.getHours()+evento.data.date.getTimezoneOffset()/60}:{("0"+evento.data.date.getMinutes()).slice(-2)}</li>}
         {evento.data.location && <li class="mb-1.5"><MapPin class="float-left mr-1"></MapPin><b>Lugar:</b> {evento.data.location}</li>}
-        {evento.data.authors && <li class="mb-1.5"><User class="float-left mr-1"></User><b>Relatores:</b> {authors.map((author,idx)=> <span> <a class="text-blue-600 hover:underline" href={author.data.portfolio} target="_blank">{author.data.name}</a>{idx < authors.length - 1 && ", "}</span>)}</li>}
-        {evento.data.video && <li><Video class="float-left mr-1"></Video><b>Vídeo:</b> <a href={evento.data.video} class="text-blue-600 hover:underline" target="_blank">Gravación da charla</a></li>}
+        {evento.data.authors && <li class="mb-1.5"><User class="float-left mr-1"></User><b>Relatores:</b> {authors.map((author,idx)=> <span> <a class="text-blue-600 dark:text-blue-400 hover:underline" href={author.data.portfolio} target="_blank">{author.data.name}</a>{idx < authors.length - 1 && ", "}</span>)}</li>}
+        {evento.data.video && <li><Video class="float-left mr-1"></Video><b>Vídeo:</b> <a href={evento.data.video} class="text-blue-600 dark:text-blue-400 hover:underline" target="_blank">Gravación da charla</a></li>}
       </ul>
     </div>
     <Prose>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,13 +21,13 @@ import CallToAction from "../components/CallToAction.astro";
 
   <!-- Sección: Próximos eventos -->
   <ContentTeaser contents={upcomingEvents} card={EventCard}>
-    <h2 slot="title" class="text-3xl font-bold text-gray-900">
+    <h2 slot="title" class="text-3xl font-bold text-gray-900 dark:text-white">
       Próximos eventos
     </h2>
     <a
       slot="more"
       href="/eventos"
-      class="text-blue-600 hover:text-blue-700 font-medium"
+      class="text-blue-600 dark:text-blue-500 hover:text-blue-700 font-medium dark:hover:text-blue-400"
     >
       Ver todos →
     </a>
@@ -35,13 +35,13 @@ import CallToAction from "../components/CallToAction.astro";
 
   <!-- Sección: Últimas noticias -->
   <ContentTeaser contents={novas} card={NovaCard}>
-    <h2 slot="title" class="text-3xl font-bold text-gray-900">
+    <h2 slot="title" class="text-3xl font-bold text-gray-900 dark:text-white">
       Últimas noticias
     </h2>
     <a
       slot="more"
       href="/novas"
-      class="text-blue-600 hover:text-blue-700 font-medium"
+      class="text-blue-600 dark:text-blue-500 hover:text-blue-700 font-medium dark:hover:text-blue-400"
     >
       Ver todas →
     </a>

--- a/src/pages/novas/[...id].astro
+++ b/src/pages/novas/[...id].astro
@@ -1,12 +1,12 @@
 ---
-import { getCollection, render } from 'astro:content';
+import { getCollection, render } from "astro:content";
 import PageLayout from "../../layouts/PageLayout.astro";
 import Card from "../../components/Card.astro";
-import Prose from '../../components/Prose.astro';
+import Prose from "../../components/Prose.astro";
 
 export async function getStaticPaths() {
-  const novas = await getCollection('novas');
-  return novas.map(nova => ({
+  const novas = await getCollection("novas");
+  return novas.map((nova) => ({
     params: { id: nova.id },
     props: { nova },
   }));
@@ -23,50 +23,53 @@ const formatDate = (date: Date) => {
   }).format(date);
 };
 ---
+
 <PageLayout
-  title=`GPUL - ${nova.data.title}` 
+  title=`GPUL - ${nova.data.title}`
   description=`${nova.data.excerpt}`
   image=`${nova.data.image.src}`
 >
   <div
-    class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3 mt-8"
+    class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3 mt-8 dark:text-white"
     id="post-body"
   >
     <h1 class="text-5xl font-semibold">{nova.data.title}</h1>
-    <p class="text-gray-500 italic">{nova.data.excerpt}</p>
+    <p class="text-gray-500 italic dark:text-neutral-300">
+      {nova.data.excerpt}
+    </p>
     {
       nova.data.tags.length > 0 && (
         <div class="flex flex-wrap gap-2 mb-4 mt-2">
           {nova.data.tags.map((tag) => (
-            <span class="px-2 py-1 bg-blue-100 text-blue-800 text-xs font-semibold rounded-full">
+            <span class="px-2 py-1 bg-blue-100 text-blue-800 dark:bg-blue-300 dark:text-blue-800 text-xs font-semibold rounded-full">
               {tag}
             </span>
           ))}
-          · {formatDate(nova.data.date)}{ (nova.data.author) ? ' - ' : ''}{nova.data.author}
+          · {formatDate(nova.data.date)}
+          {nova.data.author ? " - " : ""}
+          {nova.data.author}
         </div>
       )
     }
 
-
-  {
-    nova.data.image ? (
-      <img
-        height="200px"
-        src={nova.data.image.src}
-        class="aspect-video rounded-lg "
-      />
-    ) : (
-      <ImagePlaceholder
-        height="200px"
-        alt={imageAlt}
-        className="aspect-video rounded-lg"
-      />
-    )
-  }
+    {
+      nova.data.image ? (
+        <img
+          height="200px"
+          src={nova.data.image.src}
+          class="aspect-video rounded-lg "
+        />
+      ) : (
+        <ImagePlaceholder
+          height="200px"
+          alt={imageAlt}
+          className="aspect-video rounded-lg"
+        />
+      )
+    }
     <Prose>
       <Content />
     </Prose>
     <br />
-
   </div>
 </PageLayout>


### PR DESCRIPTION
Modo oscuro con la variante `dark` de tailwindcss.

Equivalencias de colores utilizadas:
```
text-gray-900 -> dark:text-white
text-gray-800 -> dark:text-white
text-gray-600 -> dark:text-neutral-400
text-gray-500 -> dark:text-neutral-400 (300)

bg-white -> bg-neutral-900
bg-gray-50 -> dark:bg-neutral-800

hover:text-blue-700 -> dark:hover:text-blue-300
hover:text-blue-600 -> dark:hover:text-blue-500
text-blue-700 -> dark:text-blue-800
text-blue-600 -> dark:text-blue-400
bg-blue-100 -> dark:bg-blue-300
```

Resultado:
<img width="2560" height="3054" alt="image" src="https://github.com/user-attachments/assets/945f07d2-f35d-4117-8d1c-774938d0d6a9" />
<img width="2560" height="1525" alt="image" src="https://github.com/user-attachments/assets/3b337678-d6c5-47ce-a6f1-10d1c691ac24" />
<img width="2560" height="1323" alt="image" src="https://github.com/user-attachments/assets/467d95d8-0c86-4943-b3aa-cd1a8c3b3dc6" />
<img width="2560" height="1323" alt="image" src="https://github.com/user-attachments/assets/ef9a3cea-9a4c-4e54-9cf3-b228c4d82ada" />
